### PR TITLE
Rewrite metadata cache

### DIFF
--- a/neo/api_test.go
+++ b/neo/api_test.go
@@ -18,6 +18,8 @@ func F1()         {}
 func (s0 S0) M()  {}
 func (s1 *S1) M() {}
 
+var cfg = &neo.Config{IncludeGoTestFiles: true}
+
 func TestIdentity(t *testing.T) {
 	type testcase struct {
 		msg string
@@ -54,7 +56,6 @@ func TestIdentity(t *testing.T) {
 			{msg: "function-and-method", x: F0, y: new(S0).M},
 		}
 
-		cfg := &neo.Config{}
 		for _, c := range cases {
 			t.Run(c.msg, func(t *testing.T) {
 				x := cfg.Extract(c.x)
@@ -135,7 +136,6 @@ func TestFunc(t *testing.T) {
 		{fn: new(S0).M, args: nil, returns: nil, isMethod: true},
 	}
 
-	cfg := &neo.Config{}
 	for i, c := range cases {
 		c := c
 
@@ -204,7 +204,6 @@ func TestStruct(t *testing.T) {
 		{name: "Person", ob: &Person{}, fields: []string{"Name", "Father", "Children"}},
 	}
 
-	cfg := &neo.Config{IncludeGoTestFiles: true}
 	for i, c := range cases {
 		c := c
 		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
@@ -253,7 +252,6 @@ func TestInterface(t *testing.T) {
 			modify: func(s *neo.Shape) *neo.Interface { return s.MustFunc().Args()[0].Shape.MustInterface() }},
 	}
 
-	cfg := &neo.Config{IncludeGoTestFiles: true}
 	for i, c := range cases {
 		c := c
 		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
@@ -291,7 +289,6 @@ func TestType(t *testing.T) {
 		{input: &Person{}, name: "Person", doc: "Person object"},
 	}
 
-	cfg := &neo.Config{IncludeGoTestFiles: true}
 	for i, c := range cases {
 		c := c
 		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {


### PR DESCRIPTION
- #30 

before

```console
$ go test
PASS
ok      github.com/podhmo/reflect-shape/neo     6.450s
$ go test
PASS
ok      github.com/podhmo/reflect-shape/neo     6.741s
$ go test
PASS
ok      github.com/podhmo/reflect-shape/neo     6.549s
```

after

```console
$ go test
PASS
ok      github.com/podhmo/reflect-shape/neo     3.408s
$ go test
PASS
ok      github.com/podhmo/reflect-shape/neo     3.403s
$ go test
PASS
ok      github.com/podhmo/reflect-shape/neo     3.533s
```

## debug

```console
$ DEBUG=1 go test
2023/01/14 18:13:48     NG func cache github.com/podhmo/reflect-shape/neo_test.Foo
2023/01/14 18:13:48     OK func cache github.com/podhmo/reflect-shape/neo_test.FooWithRetNames
2023/01/14 18:13:48     OK func cache github.com/podhmo/reflect-shape/neo_test.FooWithoutArgNames
2023/01/14 18:13:48     OK func cache github.com/podhmo/reflect-shape/neo_test.FooWithVariadicArgs
2023/01/14 18:13:48     NG func cache github.com/podhmo/reflect-shape/neo_test.S0.M
2023/01/14 18:13:48     OK func cache github.com/podhmo/reflect-shape/neo_test.Foo
2023/01/14 18:13:49 NG package cache github.com/podhmo/reflect-shape/neo_test
2023/01/14 18:13:49 OK package cache github.com/podhmo/reflect-shape/neo_test
2023/01/14 18:13:49     OK func cache (full) github.com/podhmo/reflect-shape/neo_test.UseContext
2023/01/14 18:13:50 NG package cache context
2023/01/14 18:13:50 OK package cache github.com/podhmo/reflect-shape/neo_test
2023/01/14 18:13:50 OK package cache github.com/podhmo/reflect-shape/neo_test
2023/01/14 18:13:51 NG package cache github.com/podhmo/reflect-shape/neo_test
PASS
ok      github.com/podhmo/reflect-shape/neo     3.324s
```