### PR TITLE
fix: if kind is reflect.Func, treated as always function

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -52,7 +52,7 @@ func (e *Extractor) extract(rt reflect.Type, rv reflect.Value) *Shape {
 	pkgPath := rt.PkgPath()
 	isMethod := false
 
-	if pkgPath == "" && id.pc != 0 {
+	if id.pc != 0 { // is function?
 		fullname := runtime.FuncForPC(id.pc).Name()
 		parts := strings.Split(fullname, ".")
 


### PR DESCRIPTION
- for https://github.com/podhmo/reflect-openapi/issues/105